### PR TITLE
fixed block order in BlockHeaders component

### DIFF
--- a/packages/page-explorer/src/BlockHeaders.tsx
+++ b/packages/page-explorer/src/BlockHeaders.tsx
@@ -28,6 +28,7 @@ function BlockHeaders ({ headers }: Props): React.ReactElement<Props> {
     >
       {headers
         .filter((header) => !!header)
+        .sort((a, b) => a.number.toNumber() > b.number.toNumber() ? -1 : 1)
         .map((header): React.ReactNode => (
           <BlockHeader
             key={header.number.toString()}


### PR DESCRIPTION
Fix blocks order in Headers component

![image](https://github.com/user-attachments/assets/9b40782a-da60-494a-a837-c4fa647d0805)


