### PR TITLE
Menu links

### DIFF
--- a/packages/apps/src/Menu/index.tsx
+++ b/packages/apps/src/Menu/index.tsx
@@ -27,17 +27,17 @@ interface Props {
 function createExternals (t: (key: string, optionsOrText?: string | { replace: Record<string, unknown> }, options?: { ns: string }) => string): ItemRoute[] {
   return [
     {
-      href: 'https://github.com/polkadot-js/apps',
+      href: 'https://github.com/QuantumFusion-network/apps',
       icon: 'code-branch',
       name: 'github',
       text: t('nav.github', 'GitHub', { ns: 'apps-routing' })
     },
-    {
-      href: 'https://wiki.polkadot.network',
-      icon: 'book',
-      name: 'wiki',
-      text: t('nav.wiki', 'Wiki', { ns: 'apps-routing' })
-    }
+    // {
+    //   href: 'https://wiki.polkadot.network',
+    //   icon: 'book',
+    //   name: 'wiki',
+    //   text: t('nav.wiki', 'Wiki', { ns: 'apps-routing' })
+    // }
   ];
 }
 


### PR DESCRIPTION
- Removed the link from top menu
- Changed github link in the menu

![image](https://github.com/user-attachments/assets/abacd156-970b-4a70-be6a-7beb215429c1)
