### PR TITLE
fix: Disable irrelevant pages for QF Network (Event calendar & Files IPFS)

### DIFF
--- a/packages/apps-routing/src/index.ts
+++ b/packages/apps-routing/src/index.ts
@@ -90,7 +90,7 @@ export default function create (t: TFunction): Routes {
     nis(t),
     gilt(t),
     scheduler(t),
-    calendar(t),
+    // calendar(t), // Disabled: irrelevant page for QF Network
     contracts(t),
     storage(t),
     extrinsics(t),
@@ -98,7 +98,7 @@ export default function create (t: TFunction): Routes {
     runtime(t),
     signing(t),
     sudo(t),
-    files(t),
+    // files(t), // Disabled: irrelevant page for QF Network
     js(t),
     utilities(t),
     settings(t)


### PR DESCRIPTION
* Disabled calendar and files routes as they are not needed for the current application context