### PR TITLE
fix: update z-index in StyledDiv component for PlayPanel

### DIFF
--- a/packages/react-components/src/Table/PlayPanel.tsx
+++ b/packages/react-components/src/Table/PlayPanel.tsx
@@ -67,7 +67,7 @@ const StyledDiv = styled.div`
   align-items: center;
   border: 1px solid #FFF;
   border-radius: 6px;
-  z-index: 1000;
+  z-index: 200;
 
   button {
     display: flex;


### PR DESCRIPTION
## Problem
The play/pause buttons in the table header were overlaying the dropdown menu 

## Solution
Reduced PlayPanel z-index from 1000 to 200 to allow dropdown menu to appear on top.

## Changes
- Modified `packages/react-components/src/Table/PlayPanel.tsx`
- Changed z-index from 1000 to 200 with explanatory comment

![image](https://github.com/user-attachments/assets/fe7f9638-5e6e-49cd-9704-fcb6dee4ed63)

Fixes #36
